### PR TITLE
Add ability to config pointfree command

### DIFF
--- a/plugin/pointfree.vim
+++ b/plugin/pointfree.vim
@@ -13,6 +13,14 @@ if !exists("g:pointfree_buf_size")
     let g:pointfree_buf_size = 2
 endif
 
+if !exists("g:pointfree_command")
+    let g:pointfree_command = exepath("pointfree")
+endif
+
+if empty("g:pointfree_command")
+    let g:pointfree_command = "pointfree"
+end
+
 " Mark a buffer as scratch
 function! s:ScratchMarkBuffer()
     setlocal buftype=nofile
@@ -86,7 +94,7 @@ fun! PointfreeGet(expression) "{{{
 
     call s:ScratchMarkBuffer()
 
-    execute '.!pointfree ' . g:pointfree_options . " '" . a:expression . "'"
+    execute '.!' . g:pointfree_command . " " . g:pointfree_options . " '" . a:expression . "'"
     setl nomodifiable
     
     let size = s:CountVisualLines()


### PR DESCRIPTION
It looks like when using ! command in (n)vim, it will run a command in
new shell, which will reset PATH base in shell setup. So if you use
direnv (or similar tool) to add pointfree into your path, the current
way to trigger pointfree won't work.

This fix introduce a new g:potion_command to allow user to override it,
and use exepath to find pointfree based on current shell session before
calling it